### PR TITLE
add codeclimate badges for maintainability score and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 🚫 Each student has a required minimum number of meaningful PRs each week per the rubric. Contributing to docs does NOT count as a PR to meet your weekly requirements.
 
-# 1️⃣ Title of project goes here
+# Workout Builder
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/ec547d1af13580d3e0b5/maintainability)](https://codeclimate.com/github/Lambda-School-Labs/Workout-Builder-fe/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/ec547d1af13580d3e0b5/test_coverage)](https://codeclimate.com/github/Lambda-School-Labs/Workout-Builder-fe/test_coverage)
 
 1️⃣ You can find the deployed project at [🚫URL NAME GOES HERE](🚫copy and paste URL here).
 


### PR DESCRIPTION
# Description

Per the Labs Engineering Standards and the Product Cycle Completion rubric, we must have a Maintainability badge and Code Coverage badge near the top of the README.

The goal is to maintain a C or higher Code Climate maintainability grade and 30% or higher Code Coverage grade.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
