### PR TITLE
display section title instead of full path

### DIFF
--- a/src/components/global/NavBar.js
+++ b/src/components/global/NavBar.js
@@ -45,9 +45,8 @@ const NavBar = ({ children, location, navigate }) => {
 
   const name = localStorage.getItem("first_name");
 
-  let title = location?.pathname
-    ? location.pathname[1].toUpperCase() + location.pathname.slice(2)
-    : "???";
+  let title = location?.pathname?.match("^/([^/]+)")[1] ?? '?';
+  if (title) title = title[0].toUpperCase() + title.slice(1);
 
   return (
     <div className="font-body">


### PR DESCRIPTION
# Description

Noticed an issue when viewing nested routes that the title gets quite long and includes /'s - this PR should fix that by only including the section in the title (Dashboard, Library, Programs, etc.)